### PR TITLE
add Github CI Action to build + validate project

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,0 +1,27 @@
+name: CI Build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18.x]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run build
+      - run: npm test

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,6 +6,7 @@
   "main": "server.js",
   "type": "module",
   "scripts": {
+    "build": "tsc --noEmit",
     "test": "jest --verbose --runInBand --testLocationInResults --setupFiles dotenv/config --passWithNoTests",
     "test:watch": "npm run test -- --watch",
     "start": "node -r dotenv/config --loader @swc-node/register/esm server.ts",

--- a/package.json
+++ b/package.json
@@ -4,12 +4,14 @@
   "private": true,
   "description": "",
   "scripts": {
+    "build": "npm run build --workspaces --if-present",
     "lint": "eslint . && prettier --check .",
     "lint:fix": "eslint --fix . && prettier --write .",
+    "prepare": "husky install",
+    "start": "concurrently -c auto 'npm:start:*'",
     "start:backend": "npm start --workspace backend",
     "start:frontend": "npm start --workspace frontend",
-    "start": "concurrently -c auto 'npm:start:*'",
-    "prepare": "husky install"
+    "test": "npm run test --workspaces --if-present"
   },
   "workspaces": [
     "backend",


### PR DESCRIPTION
Otay, final bit of tooling for a while (hopefully): this PR adds some continuous integration via [Github Actions](https://docs.github.com/en/actions) so that we can verify each PR is squeaky clean and functional.

For the npm scripts, I kept a similar pattern as in #1: running scripts from the root forwards to both backend + frontend, but you can also run individual build/test/whatever scripts in the specific subproject.