### PR TITLE
backend: `start` live reloads with any code change

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -9,10 +9,8 @@
     "build": "tsc --noEmit",
     "test": "jest --verbose --runInBand --testLocationInResults --setupFiles dotenv/config --passWithNoTests",
     "test:watch": "npm run test -- --watch",
-    "start": "node -r dotenv/config --loader @swc-node/register/esm server.ts",
-    "start:watch": "nodemon -r dotenv/config server.js",
-    "setup-db": "node -r dotenv/config setup-db.js",
-    "setup-heroku": "heroku run npm run setup-db"
+    "start": "nodemon server.ts",
+    "setup-db": "node -r dotenv/config setup-db.js"
   },
   "jest": {
     "testEnvironment": "node"
@@ -20,17 +18,18 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
+  "nodemonConfig": {
+    "execMap": {
+      "ts": "node --no-warnings=ExperimentalWarning -r dotenv/config --loader @swc-node/register/esm"
+    }
+  },
   "devDependencies": {
     "@swc-node/register": "^1.6.6",
     "@types/express": "^4.17.17",
     "@types/jest": "^28.1.1",
     "@types/pg": "^8.6.5",
-    "@typescript-eslint/eslint-plugin": "^5.60.0",
-    "@typescript-eslint/parser": "^5.60.0",
-    "eslint": "^8.43.0",
     "jest": "^28.1.0",
     "nodemon": "^2.0.16",
-    "prettier": "^2.6.2",
     "supertest": "^6.2.3"
   },
   "dependencies": {


### PR DESCRIPTION
Updates the backend's `start` script to use `nodemon` by default and watch for any changes and reload the server.

Also removes a few unused dependencies + scripts that aren't relevant anymore